### PR TITLE
[back]Auth0認証つきAPI

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -48,6 +48,7 @@ group :development do
   # gem "spring"
 end
 
+gem 'jwt', '~> 2.5'
 gem 'rubocop', require: false
 gem 'rubocop-performance', require: false
 gem 'rubocop-rails', require: false

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
       rdoc
       reline (>= 0.4.2)
     json (2.7.2)
+    jwt (2.8.1)
+      base64
     language_server-protocol (3.17.0.3)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -257,6 +259,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  jwt (~> 2.5)
   mysql2 (~> 0.5)
   puma (>= 5.0)
   rack-cors

--- a/back/app/controllers/auth/application_controller.rb
+++ b/back/app/controllers/auth/application_controller.rb
@@ -1,0 +1,41 @@
+class Auth::ApplicationController < ApplicationController
+  before_action :authorize
+
+  REQUIRES_AUTHENTICATION = { message: 'Requires authentication' }
+  BAD_CREDENTIALS = { message: 'Bad credentials' }
+  MALFORMED_AUTHORIZATION_HEADER = {
+    error: 'invalid_request',
+    error_description: 'Authorization header value must follow this format: Bearer access-token',
+    message: 'Bad credentials'
+  }
+
+  private
+
+  def authorize
+    token = token_from_request
+
+    return if performed?
+
+    validation_response = Auth0Client.validate_token(token)
+
+    return unless (error = validation_response.error)
+
+    render json: {message: error.message}, status: error.status
+  end
+
+  def token_from_request
+    authorization_header_elements = request.headers['Authorization']&.split
+
+    render json: REQUIRES_AUTHENTICATION, status: :unauthorized and return unless authorization_header_elements
+
+    unless authorization_header_elements.length == 2
+      render json: MALFORMED_AUTHORIZATION_HEADER, status: :unauthorized and return
+    end
+
+    scheme, token = authorization_header_elements
+
+    render json: BAD_CREDENTIALS, status: :unauthorized and return unless scheme.downcase == 'bearer'
+
+    token
+  end
+end

--- a/back/app/controllers/auth/test_messages_controller.rb
+++ b/back/app/controllers/auth/test_messages_controller.rb
@@ -1,0 +1,13 @@
+class Auth::TestMessagesController < Auth::ApplicationController
+  def admin
+    render json: 'This is a admin message.'
+  end
+
+  def protected
+    render json: 'This is a protected message.'
+  end
+
+  def public
+    render json: 'This is a public message.'
+  end
+end

--- a/back/app/controllers/auth/test_messages_controller.rb
+++ b/back/app/controllers/auth/test_messages_controller.rb
@@ -1,13 +1,13 @@
 class Auth::TestMessagesController < Auth::ApplicationController
   def admin
-    render json: 'This is a admin message.'
+    render json: 'This is a admin message.'.to_json
   end
 
   def protected
-    render json: 'This is a protected message.'
+    render json: 'This is a protected message.'.to_json
   end
 
   def public
-    render json: 'This is a public message.'
+    render json: 'This is a public message.'.to_json
   end
 end

--- a/back/app/lib/auth0_client.rb
+++ b/back/app/lib/auth0_client.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'jwt'
+require 'net/http'
+
+class Auth0Client
+
+  # Auth0 Client Objects
+  Error = Struct.new(:message, :status)
+  Response = Struct.new(:decoded_token, :error)
+
+  # Helper Functions
+  def self.domain_url
+    "https://#{Rails.configuration.auth0.domain}/"
+  end
+
+  def self.decode_token(token, jwks_hash)
+    JWT.decode(token, nil, true, {
+                 algorithm: 'RS256',
+                 iss: domain_url,
+                 verify_iss: true,
+                 aud: Rails.configuration.auth0.audience.to_s,
+                 verify_aud: true,
+                 jwks: { keys: jwks_hash[:keys] }
+               })
+  end
+
+  def self.get_jwks
+    jwks_uri = URI("#{domain_url}.well-known/jwks.json")
+    Net::HTTP.get_response jwks_uri
+  end
+
+  # Token Validation
+  def self.validate_token(token)
+    jwks_response = get_jwks
+
+    unless jwks_response.is_a? Net::HTTPSuccess
+      error = Error.new(message: 'Unable to verify credentials', status: :internal_server_error)
+      return Response.new(nil, error)
+    end
+
+    jwks_hash = JSON.parse(jwks_response.body).deep_symbolize_keys
+
+    decoded_token = decode_token(token, jwks_hash)
+
+    Response.new(decoded_token, nil)
+  rescue JWT::VerificationError, JWT::DecodeError => e
+    error = Error.new('Bad credentials', :unauthorized)
+    Response.new(nil, error)
+  end
+end

--- a/back/config/application.rb
+++ b/back/config/application.rb
@@ -28,5 +28,7 @@ module App
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.auth0 = config_for(:auth0)
   end
 end

--- a/back/config/auth0.yml
+++ b/back/config/auth0.yml
@@ -1,0 +1,7 @@
+development:
+  domain: <%= ENV.fetch('AUTH0_DOMAIN') %>
+  audience: <%= ENV.fetch('AUTH0_AUDIENCE') %>
+
+production:
+  domain: <%= ENV.fetch('AUTH0_DOMAIN') %>
+  audience: <%= ENV.fetch('AUTH0_AUDIENCE') %>

--- a/back/config/environments/development.rb
+++ b/back/config/environments/development.rb
@@ -70,6 +70,7 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
   config.hosts = [
     "portfolio_api-back-1:3000", # Windows
-    "back:3000" # Mac
+    "back:3000", # Mac
+    "localhost" # ブラウザ
   ]
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -1,11 +1,21 @@
 Rails.application.routes.draw do
-  resources :test_posts, only: %i[index]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
+  # 認証が必要なルーティングはここ
+  namespace :auth do
+    resource :test_messages, only: [] do
+      get 'protected'
+      get 'public'
+      get 'admin'
+    end
+  end
+  
+  # 認証が不要なルーティングはここ
+  resources :test_posts, only: %i[index]
   # Defines the root path route ("/")
   # root "posts#index"
 end

--- a/documents/Auth0.md
+++ b/documents/Auth0.md
@@ -28,7 +28,9 @@ cf: https://auth0.com/signup/?utm_source=devcenter&utm_medium=auth0&utm_campaign
 - AUTH0_CLIENT_SECRET=（Client Secretを記載）
 
 ## ユニバーサルログインの設定
-GitHubに遷移させてるので不要かも  
+<details>
+<summary>GitHubに遷移させてるので不要かも  </summary>
+
   
 遷移
 - Branding -> Universal Login -> Advanced Options
@@ -52,6 +54,48 @@ GitHubに遷移させてるので不要かも
 <img src="https://i.gyazo.com/33f7a8646cd5d4b7289c8220a77adaba.png" width="200px">
 
 Advanced Optionsから直接HTMLを編集することもできそう
+</details>  
+  
+
+## バックエンドの設定
+### Auth0 audience の設定
+遷移
+- Applications -> APIs
+- Create API
+
+設定
+- Name: Rails
+- Identifier: バックエンドのURL
+- Signing Algorithm: RS256 (default)
+
+### TENANT DOMAIN の確認
+遷移
+- Settings -> Custom Domains
+
+文章中の `dev-xxx.jp.auth0.com` を取得
+
+### back/.env の設定
+- PORT=4000（バックエンドのポート番号）
+- CLIENT_ORIGIN_URL=http://localhost:8002（フロントのURL）
+- AUTH0_AUDIENCE=http://localhost:4000（Auth0 audience の設定でIdentifierに設定した値）
+- AUTH0_DOMAIN=dev-xxx.jp.auth0.com（TENANT DOMAIN）
+
+### front/.envの設定
+- AUTH0_AUDIENCE=http://localhost:4000（Auth0 audience の設定でIdentifierに設定した値）
+
+### アクセストークンの確認
+遷移
+- Applications -> APIs -> Rails -> Test
+
+`Response` のスニペット右上のボタンからコピーし、アクセストークンを入手する
+
+### 認証付きコントローラの動作確認
+```
+curl --request GET \
+  --url http://localhost:4000/auth/test_messages/protected \
+  --header 'authorization: Bearer アクセストークン
+```
+
 
 
 # （参考）無料枠の範囲

--- a/front/app/_services/testAuthMessage.ts
+++ b/front/app/_services/testAuthMessage.ts
@@ -1,0 +1,76 @@
+import "server-only";
+
+import { getAccessToken, getSession } from "@auth0/nextjs-auth0";
+
+interface GetMessageParams {
+  type: "public" | "protected" | "admin";
+}
+
+interface Message {
+  text: string;
+}
+
+export const getTestAuthMessage = async ({
+  type,
+}: GetMessageParams): Promise<Message> => {
+  const session = await getSession();
+
+  if (!session) {
+    return {
+      text: "Requires authorization if you wanna see this text",
+    };
+  }
+
+  const { accessToken } = await getAccessToken();
+
+  if (!accessToken) {
+    return {
+      text: "Requires authorization if you wanna see this text",
+    };
+  }
+
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/auth/test_messages/${type}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+
+  if (res.ok) {
+    const json = await res.json();
+
+    return {
+      text: json,
+    };
+  }
+
+  if (!res.ok) {
+    const json = await res.json();
+
+    return {
+      text: json.message || res.statusText || "Unable to fetch",
+    };
+  }
+
+  // console.log('----- res json')
+  // const json = await res.json();
+  // console.log(json)
+  // return res.json();
+};
+
+export const getPublicMessage = async () => {
+  return {
+    text: "This is a public message!!"
+  }
+  // return getMessage({ type: "public" });
+};
+
+export const getProtectedMessage = async () => {
+  return getTestAuthMessage({ type: "protected" });
+};
+
+export const getAdminMessage = async () => {
+  return getTestAuthMessage({ type: "admin" });
+};

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -3,17 +3,20 @@ import List from './_components/buttons/list';
 import Submission from './_components/buttons/submission';
 import theme from './_constants/customTheme';
 import AuthButtons from './_layouts/nav/auth_buttons';
+import { getProtectedMessage } from './_services/testAuthMessage';
 import TestPostUI from './_services/testPost';
 
-export default function Home() {
+export default async function Home() {
+  const { text } = await getProtectedMessage();
 
   return (
     <MantineProvider theme={theme}>
       <AuthButtons />
       <Submission />
       <List />
-      {/* @ts-expect-error Server Component */}
       <TestPostUI />
+      <hr />
+      {text}
     </MantineProvider>
   );
 }


### PR DESCRIPTION
## PRの概要
バックエンド側でAuth0のトークンを検証するテスト処理を作成

## やったこと

- バックエンド
  - JWT（RS256）の検証
  - `back/app/controllers/auth` 配下のコントローラに自動でAuth0トークン検証処理を付与
  - 検証用のコントローラ `Auth::TestMessagesController` 追加
- フロント
  - トップページのPostリストの下に、ログイン／ログアウトで内容が変わるメッセージを表示

## やらなかったこと
<!-- 別PRで対応することなど -->

- `getTestAuthMessage`がPromiseになってない
  - asyncのままpageに渡すとメッセージがundefinedになってしまうので、awaitした結果をとりあえず渡している

## テスト方法
検証用なのでテストコードはない

## 画面キャプチャ
ログイン時
![image](https://github.com/ikiri-otaku/portfolio_api/assets/98746670/da0d2a8c-8e01-4def-804e-545149cbcc15)

ログアウト時
![image](https://github.com/ikiri-otaku/portfolio_api/assets/98746670/6f56a7b6-e9cd-46d2-9a73-9f59b2d9da46)


## 疑問点

- やらなかったことの解決方法

## チェックリスト
- [x] 表記ゆれを確認した
- [] カバレッジが100%であることを確認した
