### PR TITLE
[back]カバレッジ測定

### DIFF
--- a/back/.gitignore
+++ b/back/.gitignore
@@ -22,6 +22,9 @@
 !/tmp/pids/
 !/tmp/pids/.keep
 
+# Ignore SimpleCov
+/coverage/*
+
 # Ignore storage (uploaded files in development and any SQLite databases).
 /storage/*
 !/storage/.keep

--- a/back/Gemfile
+++ b/back/Gemfile
@@ -48,6 +48,10 @@ group :development do
   # gem "spring"
 end
 
+group :test do
+  gem 'simplecov', require: false
+end
+
 gem 'rubocop', require: false
 gem 'rubocop-performance', require: false
 gem 'rubocop-rails', require: false

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
+    docile (1.4.0)
     dotenv (3.1.0)
     dotenv-rails (3.1.0)
       dotenv (= 3.1.0)
@@ -235,6 +236,12 @@ GEM
       rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     stringio (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
@@ -265,6 +272,7 @@ DEPENDENCIES
   rubocop
   rubocop-performance
   rubocop-rails
+  simplecov
   tzinfo-data
 
 RUBY VERSION

--- a/back/spec/rails_helper.rb
+++ b/back/spec/rails_helper.rb
@@ -4,6 +4,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort("The Rails environment is running in development mode!") if Rails.env.development?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/back/spec/spec_helper.rb
+++ b/back/spec/spec_helper.rb
@@ -11,7 +11,27 @@
 # a separate helper file that requires the additional dependencies and performs
 # the additional setup, and require it from the spec files that actually need
 # it.
-#
+require 'simplecov'
+
+SimpleCov.start do
+  track_files '**/*.rb'
+
+  # 除外ディレクトリ
+  add_filter '/bin/'
+  add_filter '/config/'
+  add_filter '/db/'
+  add_filter '/spec/'
+
+  add_group 'Controllers', 'app/controllers'
+  add_group 'Jobs', 'app/jobs'
+  add_group 'Libs', 'app/lib'
+  add_group 'Mailers', 'app/mailers'
+  add_group 'Models', 'app/models'
+
+  # 行内の分岐カバレッジも取得
+  enable_coverage :branch
+end
+
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
## PRの概要
Rspecのカバレッジ測定gemを導入
#4 

## やったこと

- SimpleCovを追加
- カバレッジ測定結果を.gitignoreに設定

## やらなかったこと
<!-- 別PRで対応することなど -->
なし

## テスト方法

- 既存のRspecが全件通る
- カバレッジが測定できる
  - Rspecを流すとback/coverage/index.htmlが作成されます
  - ブラウザで開くと、各ファイルのカバレッジが一覧で見れます
  - ファイルパスがリンクになっていて、押すとファイルの各行のカバレッジが見れます

## 画面キャプチャ
一覧
![image](https://github.com/ikiri-otaku/portfolio_api/assets/98746670/17ac319a-779b-4894-877e-5c8b8fc6ed1c)

ファイル単位
![image](https://github.com/ikiri-otaku/portfolio_api/assets/98746670/8c14ff53-949e-41e3-93f2-f891e840290b)

## 疑問点
なし

## チェックリスト
- [x] 表記ゆれを確認した
- [x] カバレッジが100%であることを確認した
