### PR TITLE
[back]ユーザ登録API

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -52,6 +52,7 @@ group :test do
   gem 'simplecov', require: false
 end
 
+gem 'jwt', '~> 2.5'
 gem 'rubocop', require: false
 gem 'rubocop-performance', require: false
 gem 'rubocop-rails', require: false

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -112,6 +112,8 @@ GEM
       rdoc
       reline (>= 0.4.2)
     json (2.7.2)
+    jwt (2.8.1)
+      base64
     language_server-protocol (3.17.0.3)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -264,6 +266,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  jwt (~> 2.5)
   mysql2 (~> 0.5)
   puma (>= 5.0)
   rack-cors

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity_response
+
+  private
+
+  def render_unprocessable_entity_response(exception)
+    Rails.logger.info exception.record.errors.full_messages
+    Rails.logger.info exception.inspect
+    render json: { error: exception.record.errors.full_messages }, status: :unprocessable_entity
+  end
 end

--- a/back/app/controllers/auth/application_controller.rb
+++ b/back/app/controllers/auth/application_controller.rb
@@ -1,0 +1,39 @@
+class Auth::ApplicationController < ApplicationController
+  before_action :authorize
+
+  REQUIRES_AUTHENTICATION = { message: 'Requires authentication' }.freeze
+  BAD_CREDENTIALS = { message: 'Bad credentials' }.freeze
+  MALFORMED_AUTHORIZATION_HEADER = {
+    error: 'invalid_request',
+    error_description: 'Authorization header value must follow this format: Bearer access-token',
+    message: 'Bad credentials'
+  }.freeze
+
+  private
+
+  def authorize
+    token = token_from_request
+
+    return if performed?
+
+    validation_response = Auth0Client.validate_token(token)
+
+    return unless (error = validation_response.error)
+
+    render json: { message: error.message }, status: error.status
+  end
+
+  def token_from_request
+    authorization_header_elements = request.headers['Authorization']&.split
+
+    render json: REQUIRES_AUTHENTICATION, status: :unauthorized and return unless authorization_header_elements
+
+    render json: MALFORMED_AUTHORIZATION_HEADER, status: :unauthorized and return unless authorization_header_elements.length == 2
+
+    scheme, token = authorization_header_elements
+
+    render json: BAD_CREDENTIALS, status: :unauthorized and return unless scheme.downcase == 'bearer'
+
+    token
+  end
+end

--- a/back/app/controllers/auth/users_controller.rb
+++ b/back/app/controllers/auth/users_controller.rb
@@ -1,0 +1,21 @@
+class Auth::UsersController < Auth::ApplicationController
+  def create
+    user = User.new(user_params)
+    return render status: :ok if User.exists?(auth0_id: user.auth0_id)
+
+    user.save!
+    render status: :ok
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error "UserCreateFailed: #{user.errors.full_messages}"
+    raise e
+  end
+
+  # TODO: 退会
+  def destroy; end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :github_username, :auth0_id)
+  end
+end

--- a/back/app/lib/auth0_client.rb
+++ b/back/app/lib/auth0_client.rb
@@ -1,0 +1,50 @@
+require 'jwt'
+require 'net/http'
+
+class Auth0Client
+  # Auth0 Client Objects
+  Error = Struct.new(:message, :status)
+  Response = Struct.new(:decoded_token, :error)
+
+  # Token Validation
+  def self.validate_token(token)
+    jwks_response = jwks
+
+    unless jwks_response.is_a? Net::HTTPSuccess
+      error = Error.new(message: 'Unable to verify credentials', status: :internal_server_error)
+      return Response.new(nil, error)
+    end
+
+    jwks_hash = JSON.parse(jwks_response.body).deep_symbolize_keys
+
+    decoded_token = decode_token(token, jwks_hash)
+
+    Response.new(decoded_token, nil)
+  rescue JWT::VerificationError, JWT::DecodeError => e
+    Rails.logger.error "InvalidTokenError: #{e.inspect}"
+    error = Error.new('Bad credentials', :unauthorized)
+    Response.new(nil, error)
+  end
+
+  def self.jwks
+    jwks_uri = URI("#{domain_url}.well-known/jwks.json")
+    Net::HTTP.get_response jwks_uri
+  end
+
+  # Helper Functions
+  def self.domain_url
+    "https://#{Rails.configuration.auth0.domain}/"
+  end
+
+  def self.decode_token(token, jwks_hash)
+    JWT.decode(token, nil, true,
+      {
+        algorithm: 'RS256',
+        iss: domain_url,
+        verify_iss: true,
+        aud: Rails.configuration.auth0.audience.to_s,
+        verify_aud: true,
+        jwks: { keys: jwks_hash[:keys] }
+      })
+  end
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   has_many :organization_users, dependent: :destroy
   has_many :organizations, through: :organization_users
+
   validates :name, presence: true, length: { maximum: 50 }
   validates :github_username, length: { maximum: 50 }, uniqueness: true
+  validates :auth0_id, presence: true
 end

--- a/back/config/application.rb
+++ b/back/config/application.rb
@@ -28,5 +28,7 @@ module App
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.auth0 = config_for(:auth0)
   end
 end

--- a/back/config/auth0.yml
+++ b/back/config/auth0.yml
@@ -1,0 +1,11 @@
+development:
+  domain: <%= ENV.fetch('AUTH0_DOMAIN') %>
+  audience: <%= ENV.fetch('AUTH0_AUDIENCE') %>
+
+test:
+  domain: auth0.example.com
+  audience: <%= ENV.fetch('AUTH0_AUDIENCE') %>
+
+production:
+  domain: <%= ENV.fetch('AUTH0_DOMAIN') %>
+  audience: <%= ENV.fetch('AUTH0_AUDIENCE') %>

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -1,11 +1,17 @@
 Rails.application.routes.draw do
-  resources :test_posts, only: %i[index]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
+  # 認証が必要なルーティングはここ
+  namespace :auth do
+    resource :user, only: %i[create destroy]
+  end
+
+  # 認証が不要なルーティングはここ
+  resources :test_posts, only: %i[index]
   # Defines the root path route ("/")
   # root "posts#index"
 end

--- a/back/db/migrate/20240522133441_add_auth0_to_users.rb
+++ b/back/db/migrate/20240522133441_add_auth0_to_users.rb
@@ -1,0 +1,5 @@
+class AddAuth0ToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :auth0_id, :string, after: :github_username
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_12_081418) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_22_133441) do
   create_table "organization_users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "organization_id", null: false
     t.bigint "user_id", null: false
@@ -38,6 +38,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_12_081418) do
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", limit: 50, null: false
     t.string "github_username", limit: 50
+    t.string "auth0_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["github_username"], name: "index_users_on_github_username", unique: true

--- a/back/spec/factories/users.rb
+++ b/back/spec/factories/users.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :user do
     sequence :name, 'user_1'
     sequence :github_username, 'github_username_1'
+    sequence :auth0_id, 'auth0|00000001'
   end
 end

--- a/back/spec/rails_helper.rb
+++ b/back/spec/rails_helper.rb
@@ -24,7 +24,7 @@ ActiveRecord::Base.logger = Logger.new($stdout)
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -66,4 +66,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include MockAuth0Client, type: :request
 end

--- a/back/spec/requests/auth/application_spec.rb
+++ b/back/spec/requests/auth/application_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe "Auth::Application", type: :request do
+  include MockAuth0Client
+
+  describe "#authorize" do
+    let(:token) { 'valid_jwt_token' }
+    let(:headers) { { Authorization: "Bearer #{token}" } }
+
+    it 'Authorizationヘッダがない場合、401を返す' do
+      post auth_user_path
+      expect(response).to have_http_status :unauthorized
+      json = response.parsed_body
+      expect(json['message']).to eq 'Requires authentication'
+    end
+
+    it 'Authorizationヘッダが空の場合、401を返す' do
+      post auth_user_path, headers: { Authorization: '' }
+      expect(response).to have_http_status :unauthorized
+      json = response.parsed_body
+      expect(json['message']).to eq 'Bad credentials'
+      expect(json['error']).to eq 'invalid_request'
+    end
+
+    it 'Authorizationヘッダが不正の場合、401を返す' do
+      post auth_user_path, headers: { Authorization: 'rabbit token' }
+      expect(response).to have_http_status :unauthorized
+      json = response.parsed_body
+      expect(json['message']).to eq 'Bad credentials'
+      expect(json['error']).to be nil
+    end
+
+    it 'jwksのリクエストに失敗した場合、500を返す' do
+      stub_jwks_request_failure
+
+      post auth_user_path, headers:, params: {}
+      expect(response).to have_http_status :internal_server_error
+      json = response.parsed_body
+      expect(json['message']).to eq 'Unable to verify credentials'
+    end
+
+    it 'JWTが不正の場合、401を返す' do
+      allow(Rails.logger).to receive(:error)
+      stub_jwks_request
+      stub_unverified_token
+
+      post auth_user_path, headers:, params: {}
+      expect(response).to have_http_status :unauthorized
+      json = response.parsed_body
+      expect(json['message']).to eq 'Bad credentials'
+      expect(Rails.logger).to have_received(:error).with(/InvalidTokenError/)
+    end
+  end
+end

--- a/back/spec/requests/auth/users_spec.rb
+++ b/back/spec/requests/auth/users_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe "Auth::Users", type: :request do
+  let(:token) { 'valid_jwt_token' }
+  let(:headers) { { Authorization: "Bearer #{token}" } }
+
+  describe "POST   /auth/user" do
+    context '不正なアクセストークンの場合' do
+      it "404を返す" do
+        mock_auth_invlid
+
+        post auth_user_path, headers:, params: {}
+        expect(response).to have_http_status :unauthorized
+      end
+    end
+
+    context '正統なアクセスの場合' do
+      it "ユーザ作成済の場合、ユーザを作成せず200を返す" do
+        user = FactoryBot.create(:user)
+        mock_auth(token:, auth0_id: user.auth0_id)
+
+        post auth_user_path, headers:, params: { user: { auth0_id: user.auth0_id } }
+        expect(response).to have_http_status :ok
+        expect(User.count).to eq 1
+      end
+
+      it "ユーザ未作成の場合、ユーザを作成して200を返す" do
+        mock_auth
+        post auth_user_path, headers:, params: { user: { name: 'name', github_username: 'github_username', auth0_id: 'auth0_id' } }
+
+        expect(response).to have_http_status(200)
+
+        user = User.last
+        expect(user.name).to eq 'name'
+        expect(user.github_username).to eq 'github_username'
+        expect(user.auth0_id).to eq 'auth0_id'
+      end
+
+      it "ユーザ作成が失敗した場合、500を返す" do
+        allow(Rails.logger).to receive(:error)
+        mock_auth
+
+        post auth_user_path, headers:, params: { user: { name: 'name', github_username: 'github_username' } } # auth0_idの必須エラーにする
+
+        expect(response).to have_http_status :unprocessable_entity
+        expect(Rails.logger).to have_received(:error).with(/UserCreateFailed/)
+        expect(User.count).to eq 0
+      end
+    end
+  end
+
+  # TODO: describe "DELETE /auth/user"
+end

--- a/back/spec/support/mock_auth0_client.rb
+++ b/back/spec/support/mock_auth0_client.rb
@@ -1,0 +1,50 @@
+require 'jwt'
+require_relative '../../app/lib/auth0_client'
+
+module MockAuth0Client
+  @@jwks_url = "#{Auth0Client.domain_url}.well-known/jwks.json" # rubocop:disable Style/ClassVars
+  @@jwks_response_body = { # rubocop:disable Style/ClassVars
+    keys: [
+      {
+        kty: "RSA",
+        kid: "testkid1",
+        use: "sig",
+        n: "example",
+        e: "AQAB"
+      }
+    ]
+  }.to_json
+
+  attr_reader :jwks_url, :jwks_response_body
+
+  def mock_auth(token: 'valid_jwt_token', auth0_id: 'anonymous')
+    stub_jwks_request
+    stub_decode_token(token:, decoded_payload: { sub: auth0_id })
+  end
+
+  def mock_auth_invlid
+    stub_jwks_request
+    stub_unverified_token
+  end
+
+  def stub_jwks_request
+    response = instance_double(Net::HTTPSuccess, body: @@jwks_response_body, is_a?: true)
+    allow(Net::HTTP).to receive(:get_response).with(URI(@@jwks_url)).and_return(response)
+  end
+
+  def stub_jwks_request_failure
+    response = instance_double(Net::HTTPInternalServerError)
+    allow(Net::HTTP).to receive(:get_response).with(URI(@@jwks_url)).and_return(response)
+  end
+
+  def stub_decode_token(token: 'valid_jwt_token', decoded_payload: { sub: 'auth0_id' })
+    jwks_hash = JSON.parse(@@jwks_response_body, symbolize_names: true)
+
+    allow(JWT).to receive(:decode).with(token, nil, true, hash_including(jwks: { keys: jwks_hash[:keys] }))
+      .and_return([decoded_payload])
+  end
+
+  def stub_unverified_token
+    allow(Auth0Client).to receive(:decode_token).and_raise(JWT::DecodeError)
+  end
+end

--- a/documents/Auth0.md
+++ b/documents/Auth0.md
@@ -28,8 +28,10 @@ cf: https://auth0.com/signup/?utm_source=devcenter&utm_medium=auth0&utm_campaign
 - AUTH0_CLIENT_SECRET=（Client Secretを記載）
 
 ## ユニバーサルログインの設定
-GitHubに遷移させてるので不要かも  
-  
+<details>
+<summary>GitHubに遷移させてるので不要かも  </summary>
+
+
 遷移
 - Branding -> Universal Login -> Advanced Options
 
@@ -37,8 +39,8 @@ GitHubに遷移させてるので不要かも
 - Universal Login Experience: New
 - Save Changes
 
-### （参考）ログイン画面のカスタマイズ  
-  
+### （参考）ログイン画面のカスタマイズ
+
 遷移
 - Branding -> Universal Login -> Customization Options
 
@@ -52,6 +54,48 @@ GitHubに遷移させてるので不要かも
 <img src="https://i.gyazo.com/33f7a8646cd5d4b7289c8220a77adaba.png" width="200px">
 
 Advanced Optionsから直接HTMLを編集することもできそう
+</details>
+
+
+## バックエンドの設定
+### Auth0 audience の設定
+遷移
+- Applications -> APIs
+- Create API
+
+設定
+- Name: Rails
+- Identifier: バックエンドのURL
+- Signing Algorithm: RS256 (default)
+
+### TENANT DOMAIN の確認
+遷移
+- Settings -> Custom Domains
+
+文章中の `dev-xxx.jp.auth0.com` を取得
+
+### back/.env の設定
+- PORT=4000（バックエンドのポート番号）
+- CLIENT_ORIGIN_URL=http://localhost:8002（フロントのURL）
+- AUTH0_AUDIENCE=http://localhost:4000（Auth0 audience の設定でIdentifierに設定した値）
+- AUTH0_DOMAIN=dev-xxx.jp.auth0.com（TENANT DOMAIN）
+
+### front/.envの設定
+- AUTH0_AUDIENCE=http://localhost:4000（Auth0 audience の設定でIdentifierに設定した値）
+
+### アクセストークンの確認
+遷移
+- Applications -> APIs -> Rails -> Test
+
+`Response` のスニペット右上のボタンからコピーし、アクセストークンを入手する
+
+### 認証付きコントローラの動作確認
+```
+curl --request GET \
+  --url http://localhost:4000/auth/test_messages/protected \
+  --header 'authorization: Bearer アクセストークン
+```
+
 
 
 # （参考）無料枠の範囲

--- a/front/app/api/auth/[auth0]/route.ts
+++ b/front/app/api/auth/[auth0]/route.ts
@@ -1,4 +1,33 @@
-import { handleAuth, handleLogin } from '@auth0/nextjs-auth0';
+import { AfterCallback, handleAuth, handleCallback, handleLogin } from '@auth0/nextjs-auth0';
+import { NextApiRequest } from 'next';
+
+const afterCallback: AfterCallback = async (_req: NextApiRequest, session: any, _state: { [key: string]: any }) => {
+  // console.log('----- start callback')
+  const { user, accessToken } = session;
+
+  const data = {
+    user: {
+      'name': user.name,
+      'github_username': user.nickname,
+      'auth0_id': user.sub,
+    },
+  }
+
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/auth/user`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    },
+  );
+  // console.log('----- res')
+  // console.log(res.ok)
+  return session;
+};
 
 export const GET = handleAuth({
   login: handleLogin({
@@ -6,7 +35,7 @@ export const GET = handleAuth({
       connection: "github", // GitHub Login Only
       prompt: "login", // always show the login form regardless of session status
     },
-    returnTo: "/",
   }),
-  // logout: handleLogout({ returnTo: 'https://example.com' }),
+  callback: handleCallback({ afterCallback }),
+  // logout: handleLogout({ returnTo: '/profile' }),
 });


### PR DESCRIPTION
## PRの概要

- Auth0経由でログインしたユーザをDBに保存する
close #49 

## やったこと

- Auth0のAPIの設定
- front側のログインのcallbackからユーザ登録APIを叩く
- バックエンド側でAuth0のトークンの正当性を検証する
- DBに登録されていないユーザを登録する

※ログインのたびにユーザ登録APIを呼ぶ理由
Auth0をGitHub経由のログインにすると、signupのコールバックが呼ばれずloginのコールバックになってしまうため

## やらなかったこと
<!-- 別PRで対応することなど -->
フロント側の自動テスト作成

## テスト方法

認証のテスト
- Auth0へのアクセス部分をモック
- リクエストヘッダ検証
- トークンの検証

ユーザ登録APIのテスト
- ユーザ作成済の場合、ユーザを作成せず200を返す
- ユーザ未作成の場合、ユーザを作成して200を返す
- ユーザ作成が失敗した場合、500を返す


## 画面キャプチャ
ログインした際のバックエンドのログ
![image](https://github.com/ikiri-otaku/portfolio_api/assets/98746670/5eed2c55-79d7-456a-a336-202817f05135)

作成されたデータ
![image](https://github.com/ikiri-otaku/portfolio_api/assets/98746670/fa28a7cd-4d9f-415b-9d5d-4afd83f8d047)

## 疑問点
なし

## チェックリスト
- [x] 表記ゆれを確認した
- [x] カバレッジが100%であることを確認した
