### PR TITLE
[back] アプリ投稿API 詳細

### DIFF
--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity_response
+  rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
   rescue_from GithubClient::Error, with: :github_base_error
 
   private
@@ -8,6 +9,10 @@ class ApplicationController < ActionController::API
     Rails.logger.info exception.record.errors.full_messages
     Rails.logger.info exception.inspect
     render json: { error: exception.record.errors.full_messages }, status: :unprocessable_entity
+  end
+
+  def render_not_found
+    render status: :not_found
   end
 
   def github_base_error(exception)

--- a/back/app/controllers/auth/portfolios_controller.rb
+++ b/back/app/controllers/auth/portfolios_controller.rb
@@ -6,7 +6,7 @@ class Auth::PortfoliosController < Auth::ApplicationController
     @portfolio = Portfolio.eager_load(:user, :organization).find(params[:id])
     # TODO: View数更新
     # TODO: 技術、画像、LIKE、View取得
-    render status: :ok, json: @portfolio.to_api_response
+    render status: :ok, json: @portfolio.to_api_response.merge(editable: check_repo_owner?(show: true))
   end
 
   # POST   /auth/portfolios
@@ -67,8 +67,10 @@ class Auth::PortfoliosController < Auth::ApplicationController
     )
   end
 
-  def check_repo_owner?
-    return true if !@portfolio.github_repository || !@portfolio.github_repository.changed?
+  def check_repo_owner?(show: false)
+    return current_user.id == @portfolio.user_id unless @portfolio.github_repository
+
+    return true if !show && !@portfolio.github_repository.changed?
 
     @portfolio.github_repository.check_repo_owner?(current_user)
   end

--- a/back/app/controllers/auth/portfolios_controller.rb
+++ b/back/app/controllers/auth/portfolios_controller.rb
@@ -1,6 +1,14 @@
 class Auth::PortfoliosController < Auth::ApplicationController
   INVALID_GITHUB_URL = { message: 'GitHubのリポジトリが存在しないか、コラボレーターではありません' }.freeze
 
+  # GET    /auth/portfolios/:id
+  def show
+    @portfolio = Portfolio.eager_load(:user, :organization).find(params[:id])
+    # TODO: View数更新
+    # TODO: 技術、画像、LIKE、View取得
+    render status: :ok, json: @portfolio.to_api_response
+  end
+
   # POST   /auth/portfolios
   def create
     @portfolio = current_user.portfolios.new(portfolio_params)

--- a/back/app/controllers/portfolios_controller.rb
+++ b/back/app/controllers/portfolios_controller.rb
@@ -1,4 +1,8 @@
 class PortfoliosController < ApplicationController
-  # TODO
-  def show; end
+  # GET    /portfolios/:id
+  def show
+    @portfolio = Portfolio.eager_load(:user, :organization).find(params[:id])
+    # TODO: 技術、画像、LIKE、View取得
+    render status: :ok, json: @portfolio.to_api_response
+  end
 end

--- a/back/app/models/portfolio.rb
+++ b/back/app/models/portfolio.rb
@@ -58,4 +58,14 @@ class Portfolio < ApplicationRecord
       save!
     end
   end
+
+  def to_api_response
+    {
+      name:,
+      url:,
+      introduction:,
+      created_date: created_at.strftime('%Y/%m/%d'),
+      creator: organization&.name || user&.name
+    }
+  end
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   # 認証が必要なルーティングはここ
   namespace :auth do
-    resources :portfolios, only: %i[create update destroy]
+    resources :portfolios, only: %i[show create update destroy]
     resource :user, only: %i[create destroy]
   end
 

--- a/back/spec/requests/auth/portfolios_spec.rb
+++ b/back/spec/requests/auth/portfolios_spec.rb
@@ -7,6 +7,50 @@ RSpec.describe 'Auth::Portfolios', type: :request do
   let(:organization) { FactoryBot.create(:organization, :with_my_user, my_user: user, github_username: 'github-organization') }
   let(:url) { 'http://example.com' }
 
+  describe 'GET    /auth/portfolios/:id' do
+    before do
+      mock_auth(token:, auth0_id: user.auth0_id)
+      allow_any_instance_of(Octokit::Client).to receive(:repository?).and_return(true)
+      allow_any_instance_of(Octokit::Client).to receive(:collaborator?).and_return(true)
+      health_check_response = instance_double(Net::HTTPSuccess)
+      allow(health_check_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+      allow(Net::HTTP).to receive(:get_response).with(URI.parse(url)).and_return(health_check_response)
+    end
+    describe '正常系' do
+      let(:portfolio_all_fields) { FactoryBot.create(:portfolio, user:, organization:, created_at: '2020-01-05 09:30:00', github_url: "https://example.github.com/#{organization.github_username}/repo") }
+      let(:portfolio_required_fields) { FactoryBot.create(:portfolio, :required_fields, user:, created_at: '2020-01-05 09:30:00') }
+      it '必須項目のみ登録したデータを返す場合、nilの項目は空文字で返す' do
+        get auth_portfolio_path(portfolio_required_fields), headers:, params: {}
+        expect(response).to have_http_status :ok
+
+        json = response.parsed_body
+        expect(json['name']).to eq portfolio_required_fields.name
+        expect(json['url']).to eq portfolio_required_fields.url
+        expect(json['introduction']).to be nil
+        expect(json['created_date']).to eq '2020/01/05'
+        expect(json['creator']).to eq user.name
+      end
+      it '全項目を登録したデータを返す場合、整形して返す' do
+        get auth_portfolio_path(portfolio_all_fields), headers:, params: {}
+        expect(response).to have_http_status :ok
+
+        json = response.parsed_body
+        expect(json['name']).to eq portfolio_all_fields.name
+        expect(json['url']).to eq portfolio_all_fields.url
+        expect(json['introduction']).to eq 'This is a sample portfolio introduction.'
+        expect(json['created_date']).to eq '2020/01/05'
+        expect(json['creator']).to eq organization.name
+      end
+    end
+
+    describe '異常系' do
+      it '存在しないidを指定した場合、404を返す' do
+        get auth_portfolio_path(0), headers:, params: {}
+        expect(response).to have_http_status :not_found
+      end
+    end
+  end
+
   describe 'POST   /auth/portfolios' do
     describe '正常系' do
       before do

--- a/back/spec/requests/portfolios_spec.rb
+++ b/back/spec/requests/portfolios_spec.rb
@@ -1,7 +1,40 @@
 require 'rails_helper'
 
 RSpec.describe 'Portfolios', type: :request do
-  describe 'GET    /portfolios' do
-    # TODO
+  let(:user) { FactoryBot.create(:user) }
+  let(:organization) { FactoryBot.create(:organization, :with_my_user, my_user: user, github_username: 'github-organization') }
+  describe 'GET    /portfolios/:id' do
+    describe '正常系' do
+      let(:portfolio_all_fields) { FactoryBot.create(:portfolio, user:, organization:, created_at: '2020-01-05 09:30:00', github_url: "https://example.github.com/#{organization.github_username}/repo") }
+      let(:portfolio_required_fields) { FactoryBot.create(:portfolio, :required_fields, user:, created_at: '2020-01-05 09:30:00') }
+      it '必須項目のみ登録したデータを返す場合、nilの項目は空文字で返す' do
+        get portfolio_path(portfolio_required_fields)
+        expect(response).to have_http_status :ok
+
+        json = response.parsed_body
+        expect(json['name']).to eq portfolio_required_fields.name
+        expect(json['url']).to eq portfolio_required_fields.url
+        expect(json['introduction']).to be nil
+        expect(json['created_date']).to eq '2020/01/05'
+        expect(json['creator']).to eq user.name
+      end
+      it '全項目を登録したデータを返す場合、整形して返す' do
+        get portfolio_path(portfolio_all_fields)
+        expect(response).to have_http_status :ok
+
+        json = response.parsed_body
+        expect(json['name']).to eq portfolio_all_fields.name
+        expect(json['url']).to eq portfolio_all_fields.url
+        expect(json['introduction']).to eq 'This is a sample portfolio introduction.'
+        expect(json['created_date']).to eq '2020/01/05'
+        expect(json['creator']).to eq organization.name
+      end
+    end
+    describe '異常系' do
+      it '存在しないidを指定した場合、404を返す' do
+        get portfolio_path(0)
+        expect(response).to have_http_status :not_found
+      end
+    end
   end
 end


### PR DESCRIPTION
## PRの概要
アプリ投稿API 詳細
close #57 

## やったこと

- 認証付き詳細API（ログインユーザーを想定）
- 認証なし詳細API

## やらなかったこと
<!-- 別PRで対応することなど -->

- まだモデルができていないため、下記が未実装
  - View数更新
  - 技術、画像、LIKE、View取得

## テスト方法
```
Auth::Portfolios
  GET    /auth/portfolios/:id
    正常系
      必須項目のみ登録したデータを返す場合、nilの項目は空文字で返す
      全項目を登録したデータを返す場合、整形して返す
      編集権限のないポートフォリオを取得する場合、editableがfalseになる
    異常系
      存在しないidを指定した場合、404を返す
Portfolios
  GET    /portfolios/:id
    正常系
      必須項目のみ登録したデータを返す場合、nilの項目は空文字で返す
      全項目を登録したデータを返す場合、整形して返す
    異常系
      存在しないidを指定した場合、404を返す
```

## 画面キャプチャ
なし

## 疑問点
なし

## チェックリスト
- [x] 表記ゆれを確認した
- [x] カバレッジが100%であることを確認した
