### PR TITLE
Rspecがtest環境で動くよう修正

### DIFF
--- a/back/spec/rails_helper.rb
+++ b/back/spec/rails_helper.rb
@@ -1,6 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
+ENV['RAILS_ENV'] = 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?


### PR DESCRIPTION
## PRの概要
`RAILS_ENV=test bundle exec rspec`としないと、Rspecがdevelopment環境で動いていた

## やったこと

- `rails_helper.rb`で環境変数`RAILS_ENV`を強制上書き
- docker-compose.ymlで`RAILS_ENV=development`と指定されているのを上書きする必要があった

## やらなかったこと
<!-- 別PRで対応することなど -->
なし

## テスト方法

- `bundle exec rspec`で「The Rails environment is running in development mode!」が出ない
- 実行するたびにデータがtruncateされていることをログで確認

## 画面キャプチャ
なし

## 疑問点
なし

## チェックリスト
- [x] 表記ゆれを確認した
- [x] カバレッジが100%であることを確認した
