### PR TITLE
[back] Pictureモデル

### DIFF
--- a/back/app/models/picture.rb
+++ b/back/app/models/picture.rb
@@ -1,0 +1,5 @@
+class Picture < ApplicationRecord
+  belongs_to :imageable, polymorphic: true
+
+  validates :object_key, length: { maximum: 255 }
+end

--- a/back/app/models/profile.rb
+++ b/back/app/models/profile.rb
@@ -1,5 +1,7 @@
 class Profile < ApplicationRecord
   belongs_to :user
+  has_many :pictures, as: :imageable, dependent: :destroy
+
   validates :user_id, uniqueness: true
   validates :location, length: { maximum: 255 }
   validates :hireable, inclusion: { in: [true, false] }

--- a/back/db/migrate/20240707091732_create_pictures.rb
+++ b/back/db/migrate/20240707091732_create_pictures.rb
@@ -1,0 +1,10 @@
+class CreatePictures < ActiveRecord::Migration[7.1]
+  def change
+    create_table :pictures do |t|
+      t.references :imageable, polymorphic: true
+      t.string :object_key
+
+      t.timestamps
+    end
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_01_053542) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_07_091732) do
   create_table "organization_users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "organization_id", null: false
     t.bigint "user_id", null: false
@@ -27,6 +27,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_01_053542) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["github_username"], name: "index_organizations_on_github_username", unique: true
+  end
+
+  create_table "pictures", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "imageable_type"
+    t.bigint "imageable_id"
+    t.string "object_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["imageable_type", "imageable_id"], name: "index_pictures_on_imageable"
   end
 
   create_table "profiles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/back/spec/factories/profiles.rb
+++ b/back/spec/factories/profiles.rb
@@ -5,5 +5,11 @@ FactoryBot.define do
     sequence :zenn_username, 'zenn_username_1'
     sequence :qiita_username, 'qiita_username_1'
     sequence :atcoder_username, 'atcoder_username_1'
+
+    trait :with_picture do
+      after(:create) do |profile|
+        profile.pictures.create!(object_key: "profile/#{profile.id}/20240707183200.jpeg")
+      end
+    end
   end
 end

--- a/back/spec/models/picture_spec.rb
+++ b/back/spec/models/picture_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Picture, type: :model do
+  describe 'バリデーション' do
+    let(:profile) { FactoryBot.create(:profile, :with_picture) }
+    let(:picture) { profile.pictures.first }
+
+    describe 'サイズ' do
+      it 'object_key が255桁を超える場合エラーになること' do
+        picture.object_key = 'a' * 255
+        expect(picture.valid?).to be true
+        picture.object_key = 'a' * 256
+        expect(picture.valid?).to be false
+        expect(picture.errors[:object_key]).to eq ['は255文字以内で入力してください']
+      end
+    end
+  end
+
+  describe 'アソシエーション' do
+    let(:profile) { FactoryBot.create(:profile, :with_picture) }
+    let(:picture) { profile.pictures.first }
+
+    it '適切な imageable が設定されること' do
+      expect(picture.imageable_type).to eq 'Profile'
+      expect(picture.imageable_id).to eq profile.id
+    end
+  end
+end

--- a/back/spec/models/profile_spec.rb
+++ b/back/spec/models/profile_spec.rb
@@ -10,49 +10,49 @@ RSpec.describe Profile, type: :model do
         expect(profile.valid?).to be true
         profile.location = 'a' * 256
         expect(profile.valid?).to be false
-        expect(profile.errors[:location]).to eq ['is too long (maximum is 255 characters)']
+        expect(profile.errors[:location]).to eq ['は255文字以内で入力してください']
       end
       it 'company が255桁を超える場合エラーになること' do
         profile.company = 'a' * 255
         expect(profile.valid?).to be true
         profile.company = 'a' * 256
         expect(profile.valid?).to be false
-        expect(profile.errors[:company]).to eq ['is too long (maximum is 255 characters)']
+        expect(profile.errors[:company]).to eq ['は255文字以内で入力してください']
       end
       it 'work_location が255桁を超える場合エラーになること' do
         profile.work_location = 'a' * 255
         expect(profile.valid?).to be true
         profile.work_location = 'a' * 256
         expect(profile.valid?).to be false
-        expect(profile.errors[:work_location]).to eq ['is too long (maximum is 255 characters)']
+        expect(profile.errors[:work_location]).to eq ['は255文字以内で入力してください']
       end
       it 'x_username が50桁を超える場合エラーになること' do
         profile.x_username = 'a' * 50
         expect(profile.valid?).to be true
         profile.x_username = 'a' * 51
         expect(profile.valid?).to be false
-        expect(profile.errors[:x_username]).to eq ['is too long (maximum is 50 characters)']
+        expect(profile.errors[:x_username]).to eq ['は50文字以内で入力してください']
       end
       it 'zenn_username が50桁を超える場合エラーになること' do
         profile.zenn_username = 'a' * 50
         expect(profile.valid?).to be true
         profile.zenn_username = 'a' * 51
         expect(profile.valid?).to be false
-        expect(profile.errors[:zenn_username]).to eq ['is too long (maximum is 50 characters)']
+        expect(profile.errors[:zenn_username]).to eq ['は50文字以内で入力してください']
       end
       it 'qiita_username が50桁を超える場合エラーになること' do
         profile.qiita_username = 'a' * 50
         expect(profile.valid?).to be true
         profile.qiita_username = 'a' * 51
         expect(profile.valid?).to be false
-        expect(profile.errors[:qiita_username]).to eq ['is too long (maximum is 50 characters)']
+        expect(profile.errors[:qiita_username]).to eq ['は50文字以内で入力してください']
       end
       it 'atcoder_username が50桁を超える場合エラーになること' do
         profile.atcoder_username = 'a' * 50
         expect(profile.valid?).to be true
         profile.atcoder_username = 'a' * 51
         expect(profile.valid?).to be false
-        expect(profile.errors[:atcoder_username]).to eq ['is too long (maximum is 50 characters)']
+        expect(profile.errors[:atcoder_username]).to eq ['は50文字以内で入力してください']
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe Profile, type: :model do
         expect(profile.valid?).to be true
         profile.hireable = nil
         expect(profile.valid?).to be false
-        expect(profile.errors[:hireable]).to eq ['is not included in the list']
+        expect(profile.errors[:hireable]).to eq ['は一覧にありません']
       end
     end
 
@@ -77,28 +77,43 @@ RSpec.describe Profile, type: :model do
       it 'user_id が重複する場合エラーになること' do
         another_profile.user_id = profile.user_id
         expect(another_profile.valid?).to be false
-        expect(another_profile.errors[:user_id]).to eq ['has already been taken']
+        expect(another_profile.errors[:user_id]).to eq ['はすでに存在します']
       end
       it 'x_username が重複する場合エラーになること' do
         another_profile.x_username = profile.x_username
         expect(another_profile.valid?).to be false
-        expect(another_profile.errors[:x_username]).to eq ['has already been taken']
+        expect(another_profile.errors[:x_username]).to eq ['はすでに存在します']
       end
       it 'zenn_username が重複する場合エラーになること' do
         another_profile.zenn_username = profile.zenn_username
         expect(another_profile.valid?).to be false
-        expect(another_profile.errors[:zenn_username]).to eq ['has already been taken']
+        expect(another_profile.errors[:zenn_username]).to eq ['はすでに存在します']
       end
       it 'qiita_username が重複する場合エラーになること' do
         another_profile.qiita_username = profile.qiita_username
         expect(another_profile.valid?).to be false
-        expect(another_profile.errors[:qiita_username]).to eq ['has already been taken']
+        expect(another_profile.errors[:qiita_username]).to eq ['はすでに存在します']
       end
       it 'atcoder_username が重複する場合エラーになること' do
         another_profile.atcoder_username = profile.atcoder_username
         expect(another_profile.valid?).to be false
-        expect(another_profile.errors[:atcoder_username]).to eq ['has already been taken']
+        expect(another_profile.errors[:atcoder_username]).to eq ['はすでに存在します']
       end
+    end
+  end
+
+  describe 'アソシエーション' do
+    let(:profile) { FactoryBot.create(:profile, :with_picture) }
+    let(:picture) { profile.pictures.first }
+
+    it '削除すると、関連するデータも削除されること' do
+      profile.save!
+      expect(Picture.where(id: picture.id).count).to eq 1
+
+      profile.destroy!
+
+      expect(Profile.where(id: profile.id).count).to eq 0
+      expect(Picture.where(id: picture.id).count).to eq 0
     end
   end
 end


### PR DESCRIPTION
## PRの概要
Pictureモデルの作成　#128 

## やったこと

- Pictureモデル
- polymorphic先としてProfileモデルを設定
- ついでに`back/spec/models/profile_spec.rb`を日本語化

## やらなかったこと
<!-- 別PRで対応することなど -->
- Portfolioモデルとの紐づけ（mainにマージされていないため）

## テスト方法
```
Picture
  バリデーション
    サイズ
      object_key が255桁を超える場合エラーになること
  アソシエーション
    適切な imageable が設定されること
Profile
  アソシエーション
    削除すると、関連するデータも削除されること
```


## 画面キャプチャ
なし

## 疑問点
なし

## チェックリスト
- [x] 表記ゆれを確認した
- [x] カバレッジが100%であることを確認した
