### PR TITLE
検索結果をアプリ一覧に表示

### DIFF
--- a/back/app/controllers/portfolios_controller.rb
+++ b/back/app/controllers/portfolios_controller.rb
@@ -5,4 +5,12 @@ class PortfoliosController < ApplicationController
     # TODO: 技術、画像、LIKE、View取得
     render status: :ok, json: @portfolio.to_api_response
   end
+
+  # キーワード検索
+  # GET    /portfolios/search
+  def search
+    portfolios = Portfolio.where("name LIKE ? OR introduction LIKE ?", "%#{params[:query]}%", "%#{params[:query]}%").limit(30)
+    # TODO: 検索対象項目
+    render status: :ok, json: portfolios.map(&:to_api_response)
+  end
 end

--- a/back/app/models/portfolio.rb
+++ b/back/app/models/portfolio.rb
@@ -64,6 +64,7 @@ class Portfolio < ApplicationRecord
 
   def to_api_response
     {
+      id:,
       name:,
       url:,
       introduction:,

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -12,7 +12,11 @@ Rails.application.routes.draw do
   end
 
   # 認証が不要なルーティングはここ
-  resources :portfolios, only: %i[show]
+  resources :portfolios, only: %i[show] do
+    collection do
+      get 'search'
+    end
+  end
   resources :teches, only: %i[index]
   resources :test_posts, only: %i[index]
   # Defines the root path route ('/')

--- a/back/spec/requests/portfolios_spec.rb
+++ b/back/spec/requests/portfolios_spec.rb
@@ -37,4 +37,40 @@ RSpec.describe 'Portfolios', type: :request do
       end
     end
   end
+
+  describe 'GET    /portfolios/search' do
+    let!(:portfolio_name_match) { FactoryBot.create(:portfolio, :required_fields, user:, name: 'wordxxxword') }
+    let!(:portfolio_introduction_match) { FactoryBot.create(:portfolio, :required_fields, user:, introduction: 'wordxxxword') }
+    let!(:portfolio_no_match) { FactoryBot.create(:portfolio, :required_fields, user:) }
+    it 'クエリパラメータが存在しない場合、全件を返す' do
+      get search_portfolios_path
+      expect(response).to have_http_status :ok
+      json = response.parsed_body
+      expect(json.length).to eq 3
+      res_str = json.to_json
+      expect(res_str).to include portfolio_name_match.name
+      expect(res_str).to include portfolio_introduction_match.name
+      expect(res_str).to include portfolio_no_match.name
+    end
+    it 'クエリパラメータが空の場合、全件を返す' do
+      get search_portfolios_path(query: '')
+      expect(response).to have_http_status :ok
+      json = response.parsed_body
+      expect(json.length).to eq 3
+      res_str = json.to_json
+      expect(res_str).to include portfolio_name_match.name
+      expect(res_str).to include portfolio_introduction_match.name
+      expect(res_str).to include portfolio_no_match.name
+    end
+    it 'クエリパラメータが指定された場合、name または introduction がマッチする結果を返す' do
+      get search_portfolios_path(query: 'xxx')
+      expect(response).to have_http_status :ok
+      json = response.parsed_body
+      expect(json.length).to eq 2
+      res_str = json.to_json
+      expect(res_str).to include portfolio_name_match.name
+      expect(res_str).to include portfolio_introduction_match.name
+      expect(res_str).not_to include portfolio_no_match.name
+    end
+  end
 end

--- a/front/app/_components/forms/searchInput.tsx
+++ b/front/app/_components/forms/searchInput.tsx
@@ -1,9 +1,21 @@
+'use client';
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { TextInput } from "@mantine/core";
+
 import { ArrowRightIcon } from "@/app/_components/icons/arrowRightIcon";
 import { SearchIcon } from "@/app/_components/icons/searchIcon";
-import { TextInput } from "@mantine/core";
 import classes from "./searchForm.module.css";
 
 export default function SearchInput() {
+  const router = useRouter();
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const handleSearch = () => {
+    router.push(`/portfolios?query=${encodeURIComponent(searchQuery)}`);
+  };
+
   return (
     <TextInput
       radius="xl"
@@ -14,10 +26,12 @@ export default function SearchInput() {
       leftSectionPointerEvents="none"
       leftSection={<SearchIcon width="18px" height="18px" stroke="#CED4DA" />}
       rightSection={
-        <button className="flex justify-center items-center w-8 h-8 bg-main relative rounded-full">
+        <button onClick={handleSearch} className="flex justify-center items-center w-8 h-8 bg-main relative rounded-full">
           <ArrowRightIcon width="18px" height="18px" fill="#CED4DA" />
         </button>
       }
+      value={searchQuery}
+      onChange={(e) => setSearchQuery(e.currentTarget.value)}
       classNames={classes}
     />
   );

--- a/front/app/_types/portfolios.ts
+++ b/front/app/_types/portfolios.ts
@@ -1,0 +1,6 @@
+export type Portfolio = {
+  id: number;
+  name: string;
+  url?: string;
+  introduction?: string;
+}

--- a/front/app/api/portfolios/search/route.ts
+++ b/front/app/api/portfolios/search/route.ts
@@ -1,0 +1,34 @@
+import { Portfolio } from "@/app/_types/portfolios";
+
+export type PortfolioSearchResponse = {
+  success: boolean;
+  portfolios: Portfolio[]
+}
+
+export async function GET(req: Request): Promise<Response> {
+  try {
+    const url = new URL(req.url);
+    const query = url.searchParams.get('query') || '';
+
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/portfolios/search?query=${encodeURIComponent(query)}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const res = await response.json();
+    const result: PortfolioSearchResponse = { success: true, portfolios: res };
+
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+
+  } catch (error: any) {
+    console.error(error);
+    return new Response(`Failed: ${error.message}`, {status: 500});
+  }
+}

--- a/front/app/globals.css
+++ b/front/app/globals.css
@@ -26,6 +26,11 @@ body {
   color: rgb(var(--foreground-rgb));
 }
 
+main {
+  margin-top: 80px;
+  padding: 2rem;
+}
+
 p {
   margin: 0;
 }

--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import { UserProvider } from "@auth0/nextjs-auth0/client";
-import "./globals.css";
-import '@mantine/core/styles.css';
 import { ColorSchemeScript, MantineProvider } from '@mantine/core';
-
-import Footer from "./_layouts/footer";
+import '@mantine/core/styles.css';
 import "./globals.css";
+import { UserProvider } from "@auth0/nextjs-auth0/client";
+
+import theme from '@/app/_constants/customTheme';
+import Footer from "@/app/_layouts/footer";
 import Header from "@/app/_layouts/header";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -28,9 +28,10 @@ export default function RootLayout({
       </head>
       <body>
         <UserProvider>
-          <MantineProvider>
-            {children}
-            <Footer />
+         <MantineProvider theme={theme}>
+          <Header />
+          <main>{children}</main>
+          <Footer />
           </MantineProvider>
         </UserProvider>
       </body>

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -1,18 +1,9 @@
-import { MantineProvider } from '@mantine/core';
-import List from './_components/buttons/list';
-import Submission from './_components/buttons/submission';
-import theme from './_constants/customTheme';
-import AuthButtons from './_layouts/nav/auth_buttons';
-import TestPostUI from './_services/testPost';
-import Header from '@/app/_layouts/header';
+import Submission from '@/app/_components/buttons/submission';
+import TestPostUI from '@/app/_services/testPost';
 
 export default function Home() {
   return (
-    <MantineProvider theme={theme}>
-      <Header />
-      <AuthButtons />
-      <List />
-      {/* @ts-expect-error Server Component */}
+    <div>
       <TestPostUI />
       <section className="flex flex-col items-center justify-center pb-14 pt-[86px]">
         <h2 className="text-center text-2xl font-black leading-snug text-textBlack">
@@ -27,6 +18,6 @@ export default function Home() {
         </p>
         <Submission />
       </section>
-    </MantineProvider>
+    </div>
   );
 }

--- a/front/app/portfolios/page.tsx
+++ b/front/app/portfolios/page.tsx
@@ -1,0 +1,37 @@
+import { Flex, Text, Title } from "@mantine/core";
+
+import { PortfolioSearchResponse } from "@/app/api/portfolios/search/route";
+
+export default async function PortfoliosPage({ searchParams  }: { searchParams : { query?: string } }) {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_FRONT_URL}/api/portfolios/search?query=${encodeURIComponent(searchParams.query || '')}`,
+    { cache: 'no-cache' },
+  );
+  const data: PortfolioSearchResponse = await res.json();
+
+  return (
+    <div>
+      <Title order={1}>アプリ一覧</Title>
+
+      {/* TODO: sort */}
+      <Flex gap="md">
+        <Text>投稿日</Text>
+        <Text>いいね数</Text>
+        <Text>View数</Text>
+      </Flex>
+
+      {data.portfolios.length === 0 ? (
+        <Text>検索結果がありません</Text>
+      ) : (
+        /* TODO: アプリカード */
+        data.portfolios.map((portfolio) => (
+          <Flex key={portfolio.id} gap="md">
+            <Text>{portfolio.name}</Text>
+            <Text>{portfolio.url}</Text>
+            <Text>{portfolio.introduction}</Text>
+          </Flex>
+        ))
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## PRの概要
#87 

## やったこと

- 検索ボックスに入力されたフリーワードでアプリを検索
- 検索対象項目：アプリ名、説明
- アプリ一覧画面に遷移し、結果を表示

## やらなかったこと
<!-- 別PRで対応することなど -->

- アプリ一覧画面の並び替え
- アプリカードのデザイン適用
- アプリの使用技術による検索
- ローディング表示

## テスト方法

## 画面キャプチャ
検索ボックスから検索
![image](https://github.com/user-attachments/assets/ceeda70c-027f-4f31-9680-2ce6f04b75a1)

検索結果を表示
![image](https://github.com/user-attachments/assets/e9f9ce7a-ffa5-4893-8e97-f75e0acd3fb9)

検索結果がない場合
![image](https://github.com/user-attachments/assets/3f52bf07-12d2-4f48-8aa5-30cc8546e70c)


## 疑問点
なし

## チェックリスト
- [x] 表記ゆれを確認した
- [x] カバレッジが100%であることを確認した
