### PR TITLE
[front] 検索ボックス作成＿

### DIFF
--- a/back/app/controllers/portfolios_controller.rb
+++ b/back/app/controllers/portfolios_controller.rb
@@ -1,7 +1,7 @@
 class PortfoliosController < ApplicationController
   # GET    /portfolios/:id
   def show
-    @portfolio = Portfolio.eager_load(:user, :organization).find(params[:id])
+    @portfolio = Portfolio.eager_load(:user, :organization, :pictures).find(params[:id])
     # TODO: 技術、画像、LIKE、View取得
     render status: :ok, json: @portfolio.to_api_response
   end
@@ -9,7 +9,7 @@ class PortfoliosController < ApplicationController
   # キーワード検索
   # GET    /portfolios/search
   def search
-    portfolios = Portfolio.where('name LIKE ? OR introduction LIKE ?', "%#{params[:query]}%", "%#{params[:query]}%").limit(30)
+    portfolios = Portfolio.includes(:pictures).where('name LIKE ? OR introduction LIKE ?', "%#{params[:query]}%", "%#{params[:query]}%").limit(30)
     # TODO: 検索対象項目
     render status: :ok, json: portfolios.map(&:to_api_response)
   end

--- a/back/app/controllers/portfolios_controller.rb
+++ b/back/app/controllers/portfolios_controller.rb
@@ -9,8 +9,7 @@ class PortfoliosController < ApplicationController
   # キーワード検索
   # GET    /portfolios/search
   def search
-    portfolios = Portfolio.includes(:pictures).where('name LIKE ? OR introduction LIKE ?', "%#{params[:query]}%", "%#{params[:query]}%").limit(30)
-    # TODO: 検索対象項目
+    portfolios = Portfolio.includes(:pictures).keyword_like(params[:query]).limit(30)
     render status: :ok, json: portfolios.map(&:to_api_response)
   end
 end

--- a/back/app/models/portfolio.rb
+++ b/back/app/models/portfolio.rb
@@ -3,6 +3,7 @@ class Portfolio < ApplicationRecord
 
   belongs_to :user, optional: true
   belongs_to :organization, optional: true
+  has_many :pictures, as: :imageable, dependent: :destroy
   has_many :portfolio_teches, dependent: :destroy
   has_many :teches, through: :portfolio_teches
   has_one :github_repository, dependent: :destroy

--- a/back/app/models/portfolio.rb
+++ b/back/app/models/portfolio.rb
@@ -15,6 +15,13 @@ class Portfolio < ApplicationRecord
     format: { with: URI::DEFAULT_PARSER.make_regexp(['http', 'https']) }
   validates :unhealthy_cnt, numericality: { only_integer: true, less_than_or_equal_to: 4, greater_than_or_equal_to: 0 }
 
+  scope :keyword_like, lambda { |keyword|
+    left_joins(:teches).where(
+      'LOWER(portfolios.name) LIKE :keyword OR LOWER(portfolios.introduction) LIKE :keyword OR LOWER(teches.name) LIKE :keyword',
+      keyword: "%#{keyword&.downcase}%"
+    ).distinct
+  }
+
   def github_url
     return unless github_repository
 

--- a/back/app/models/portfolio.rb
+++ b/back/app/models/portfolio.rb
@@ -70,7 +70,8 @@ class Portfolio < ApplicationRecord
       url:,
       introduction:,
       created_date: created_at.strftime('%Y/%m/%d'),
-      creator: organization&.name || user&.name
+      creator: organization&.name || user&.name,
+      pictures: pictures.map { |picture| "#{picture.imageable_type}/#{picture.object_key}" }
     }
   end
 end

--- a/back/spec/factories/portfolios.rb
+++ b/back/spec/factories/portfolios.rb
@@ -21,6 +21,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_picture do
+      after(:create) do |portfolio|
+        portfolio.pictures.create!(object_key: "portfolio/#{portfolio.id}/20240707183200.jpeg")
+      end
+    end
+
     trait :with_tech do
       after(:create) do |portfolio|
         portfolio.teches << FactoryBot.create(:tech) if portfolio.teches.blank?

--- a/back/spec/factories/portfolios.rb
+++ b/back/spec/factories/portfolios.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
 
     trait :with_picture do
       after(:create) do |portfolio|
-        portfolio.pictures.create!(object_key: "portfolio/#{portfolio.id}/20240707183200.jpeg")
+        portfolio.pictures.create!(object_key: 'Portfolio/20240928/with_picture.jpeg')
       end
     end
 

--- a/back/spec/models/portfolio_spec.rb
+++ b/back/spec/models/portfolio_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Portfolio, type: :model do
   describe 'アソシエーション' do
     let!(:user) { FactoryBot.create(:user) }
     let!(:organization) { FactoryBot.create(:organization) }
-    let!(:portfolio) { FactoryBot.create(:portfolio, user:, organization:) }
+    let!(:portfolio) { FactoryBot.create(:portfolio, :with_picture, user:, organization:) }
 
     it 'userの削除時にportfolioをnulに設定' do
       user.destroy
@@ -86,6 +86,15 @@ RSpec.describe Portfolio, type: :model do
     it 'organizationの削除時にportfolioをnulに設定' do
       organization.destroy
       expect(portfolio.reload.organization).to be_nil
+    end
+
+    it '削除すると、関連するデータも削除されること' do
+      expect(Picture.where(imageable_type: 'Portfolio', imageable_id: portfolio.id).count).to eq 1
+
+      portfolio.destroy!
+
+      expect(Portfolio.where(id: portfolio.id).count).to eq 0
+      expect(Picture.where(imageable_type: 'Portfolio', imageable_id: portfolio.id).count).to eq 0
     end
 
     describe 'github_repository' do

--- a/back/spec/models/portfolio_spec.rb
+++ b/back/spec/models/portfolio_spec.rb
@@ -106,9 +106,35 @@ RSpec.describe Portfolio, type: :model do
   end
 
   describe 'メソッド' do
+    # organization
     let(:organization) { FactoryBot.create(:organization, :with_user) }
     let(:user_with_org) { organization.users.first }
+    # user
     let(:user_no_org) { FactoryBot.create(:user) }
+
+    describe '.keyword_like' do
+      # tech
+      let!(:tech_ruby) { FactoryBot.create(:tech, name: 'Ruby') }
+      let!(:tech_keyword) { FactoryBot.create(:tech, name: 'tech_keyword') }
+      # portfolio
+      let!(:portfolio_1) { FactoryBot.create(:portfolio, name: 'xkeywordx') }
+      let!(:portfolio_2) { FactoryBot.create(:portfolio, introduction: 'xkeywordx') }
+      let!(:portfolio_3) { FactoryBot.create(:portfolio) }
+
+      before do
+        portfolio_2.teches << tech_ruby
+        portfolio_3.teches << tech_keyword
+      end
+
+      it 'keywordが指定されていない場合、全件取得できる' do
+        expect(Portfolio.keyword_like('').pluck(:id)).to eq [portfolio_1.id, portfolio_2.id, portfolio_3.id]
+      end
+
+      it 'keywordが指定された場合、一致した結果が取得できる' do
+        expect(Portfolio.keyword_like('KeyWord').pluck(:id)).to eq [portfolio_1.id, portfolio_2.id, portfolio_3.id]
+        expect(Portfolio.keyword_like('ruby').pluck(:id)).to eq [portfolio_2.id]
+      end
+    end
 
     describe '#github_url' do
       let(:portfolio) { FactoryBot.build(:portfolio) }

--- a/back/spec/requests/portfolios_spec.rb
+++ b/back/spec/requests/portfolios_spec.rb
@@ -3,10 +3,13 @@ require 'rails_helper'
 RSpec.describe 'Portfolios', type: :request do
   let(:user) { FactoryBot.create(:user) }
   let(:organization) { FactoryBot.create(:organization, :with_my_user, my_user: user, github_username: 'github-organization') }
+
   describe 'GET    /portfolios/:id' do
     describe '正常系' do
+      # portfolio
       let(:portfolio_all_fields) { FactoryBot.create(:portfolio, user:, organization:, created_at: '2020-01-05 09:30:00', github_url: "https://example.github.com/#{organization.github_username}/repo") }
       let(:portfolio_required_fields) { FactoryBot.create(:portfolio, :required_fields, user:, created_at: '2020-01-05 09:30:00') }
+
       it '必須項目のみ登録したデータを返す場合、nilの項目は空文字で返す' do
         get portfolio_path(portfolio_required_fields)
         expect(response).to have_http_status :ok
@@ -17,8 +20,11 @@ RSpec.describe 'Portfolios', type: :request do
         expect(json['introduction']).to be nil
         expect(json['created_date']).to eq '2020/01/05'
         expect(json['creator']).to eq user.name
+        expect(json['pictures']).to eq []
       end
       it '全項目を登録したデータを返す場合、整形して返す' do
+        2.times.each { |i| portfolio_all_fields.pictures.create!(object_key: "20240928/picture_#{i}.png") }
+
         get portfolio_path(portfolio_all_fields)
         expect(response).to have_http_status :ok
 
@@ -28,6 +34,7 @@ RSpec.describe 'Portfolios', type: :request do
         expect(json['introduction']).to eq 'This is a sample portfolio introduction.'
         expect(json['created_date']).to eq '2020/01/05'
         expect(json['creator']).to eq organization.name
+        expect(json['pictures']).to eq ['Portfolio/20240928/picture_0.png', 'Portfolio/20240928/picture_1.png']
       end
     end
     describe '異常系' do
@@ -39,9 +46,9 @@ RSpec.describe 'Portfolios', type: :request do
   end
 
   describe 'GET    /portfolios/search' do
-    let!(:portfolio_name_match) { FactoryBot.create(:portfolio, :required_fields, user:, name: 'wordxxxword') }
-    let!(:portfolio_introduction_match) { FactoryBot.create(:portfolio, :required_fields, user:, introduction: 'wordxxxword') }
-    let!(:portfolio_no_match) { FactoryBot.create(:portfolio, :required_fields, user:) }
+    let!(:portfolio_name_match) { FactoryBot.create(:portfolio, :required_fields, :with_picture, user:, name: 'wordxxxword') }
+    let!(:portfolio_introduction_match) { FactoryBot.create(:portfolio, :required_fields, :with_picture, user:, introduction: 'wordxxxword') }
+    let!(:portfolio_no_match) { FactoryBot.create(:portfolio, :required_fields, :with_picture, user:) }
     it 'クエリパラメータが存在しない場合、全件を返す' do
       get search_portfolios_path
       expect(response).to have_http_status :ok

--- a/back/spec/requests/portfolios_spec.rb
+++ b/back/spec/requests/portfolios_spec.rb
@@ -54,30 +54,27 @@ RSpec.describe 'Portfolios', type: :request do
       expect(response).to have_http_status :ok
       json = response.parsed_body
       expect(json.length).to eq 3
-      res_str = json.to_json
-      expect(res_str).to include portfolio_name_match.name
-      expect(res_str).to include portfolio_introduction_match.name
-      expect(res_str).to include portfolio_no_match.name
+      expect(json.dig(0, 'name')).to eq portfolio_name_match.name
+      expect(json.dig(0, 'pictures', 0)).to eq "Portfolio/#{portfolio_name_match.pictures.first.object_key}"
+      expect(json.dig(1, 'name')).to eq portfolio_introduction_match.name
+      expect(json.dig(2, 'name')).to eq portfolio_no_match.name
     end
     it 'クエリパラメータが空の場合、全件を返す' do
       get search_portfolios_path(query: '')
       expect(response).to have_http_status :ok
       json = response.parsed_body
       expect(json.length).to eq 3
-      res_str = json.to_json
-      expect(res_str).to include portfolio_name_match.name
-      expect(res_str).to include portfolio_introduction_match.name
-      expect(res_str).to include portfolio_no_match.name
+      expect(json.dig(0, 'name')).to eq portfolio_name_match.name
+      expect(json.dig(1, 'name')).to eq portfolio_introduction_match.name
+      expect(json.dig(2, 'name')).to eq portfolio_no_match.name
     end
     it 'クエリパラメータが指定された場合、name または introduction がマッチする結果を返す' do
       get search_portfolios_path(query: 'xxx')
       expect(response).to have_http_status :ok
       json = response.parsed_body
       expect(json.length).to eq 2
-      res_str = json.to_json
-      expect(res_str).to include portfolio_name_match.name
-      expect(res_str).to include portfolio_introduction_match.name
-      expect(res_str).not_to include portfolio_no_match.name
+      expect(json.dig(0, 'name')).to eq portfolio_name_match.name
+      expect(json.dig(1, 'name')).to eq portfolio_introduction_match.name
     end
   end
 end

--- a/front/app/_components/images/picture.tsx
+++ b/front/app/_components/images/picture.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Image from "next/image";
+import { useEffect, useState } from "react";
+
+interface Props {
+  s3Key: string;
+  width: number;
+  height: number;
+}
+
+export default function Picture({ s3Key, width, height }: Props) {
+  const [signedUrl, setSignedUrl] = useState('');
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchSignedUrl = async () => {
+      try {
+        const signedResponse = await fetch(`/api/s3-signed-url?key=${encodeURIComponent(s3Key)}`);
+        const signedResult = await signedResponse.json();
+        setSignedUrl(signedResult.url);
+      } catch (error) {
+        setError(error instanceof Error ? error.message : String(error));
+      }
+    };
+
+    fetchSignedUrl();
+  }, [s3Key]);
+
+  if (error) return <div>Error: {error}</div>
+
+  return (
+    <Image src={signedUrl} alt={s3Key} width={width} height={height} />
+  );
+}

--- a/front/app/_types/portfolios.ts
+++ b/front/app/_types/portfolios.ts
@@ -3,4 +3,5 @@ export type Portfolio = {
   name: string;
   url?: string;
   introduction?: string;
+  pictures: string[];
 }

--- a/front/app/api/portfolios/search/route.ts
+++ b/front/app/api/portfolios/search/route.ts
@@ -15,6 +15,7 @@ export async function GET(req: Request): Promise<Response> {
       headers: {
         'Content-Type': 'application/json',
       },
+      cache: 'no-cache',
     });
 
     const res = await response.json();
@@ -29,6 +30,6 @@ export async function GET(req: Request): Promise<Response> {
 
   } catch (error: any) {
     console.error(error);
-    return new Response(`Failed: ${error.message}`, {status: 500});
+    return new Response(`Failed: ${error.message}`, { status: 500 });
   }
 }

--- a/front/app/portfolios/page.tsx
+++ b/front/app/portfolios/page.tsx
@@ -1,8 +1,9 @@
 import { Flex, Text, Title } from "@mantine/core";
 
 import { PortfolioSearchResponse } from "@/app/api/portfolios/search/route";
+import Picture from "@/app/_components/images/picture";
 
-export default async function PortfoliosPage({ searchParams  }: { searchParams : { query?: string } }) {
+export default async function PortfoliosPage({ searchParams }: { searchParams: { query?: string } }) {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_FRONT_URL}/api/portfolios/search?query=${encodeURIComponent(searchParams.query || '')}`,
     { cache: 'no-cache' },
@@ -29,6 +30,12 @@ export default async function PortfoliosPage({ searchParams  }: { searchParams :
             <Text>{portfolio.name}</Text>
             <Text>{portfolio.url}</Text>
             <Text>{portfolio.introduction}</Text>
+            {portfolio.pictures.length > 0 ? (
+              <Picture s3Key={portfolio.pictures[0]} width={100} height={100} />
+            ) : (
+              // TODO 画像がないとき用の画像
+              <p>No image</p>
+            )}
           </Flex>
         ))
       )}


### PR DESCRIPTION
## PRの概要
close #87 

## やったこと

- ポートフォリオの画像取得
- キーワード検索対象に使用技術を追加

## やらなかったこと
<!-- 別PRで対応することなど -->
なし

## テスト方法
```
Portfolio
  アソシエーション
    削除すると、関連するデータも削除されること
  メソッド
    .keyword_like
      keywordが指定されていない場合、全件取得できる
      keywordが指定された場合、一致した結果が取得できる
Portfolios
  GET    /portfolios/:id
    正常系
      必須項目のみ登録したデータを返す場合、nilの項目は空文字で返す
        ⇒画像未設定時の取得結果を追加
      全項目を登録したデータを返す場合、整形して返す
        ⇒画像複数設定時の取得結果を追加
  GET    /portfolios/search
    クエリパラメータが存在しない場合、全件を返す
      ⇒画像単数設定時の取得結果を追加
```

## 画面キャプチャ
![image](https://github.com/user-attachments/assets/c78e09c4-1dfb-48bc-add4-0a2e682ca4a3)

## 疑問点
なし
## チェックリスト
- [x] 表記ゆれを確認した
- [x] カバレッジが100%であることを確認した
